### PR TITLE
Added test showing that type hint names can be used when using namespaces

### DIFF
--- a/Zend/tests/typehints/scalar_reserved7.phpt
+++ b/Zend/tests/typehints/scalar_reserved7.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Scalar type hint names can be used as class on non-global namespace (7)
+--FILE--
+<?php
+
+namespace typehint;
+
+class string {}
+echo 'OK';
+--EXPECT--
+OK


### PR DESCRIPTION
@TazeTSchnitzel The scalar type names are not available only on global/root namespace. Using these names on namespaces it is fine. I added this test to make sure future changes doesn't break it. Or should the code be changed to not allow it?
